### PR TITLE
Add possibility to set executable path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ hs_err_pid*
 
 .idea
 *.iml
+
+# No target build for github
+target/

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.sapher</groupId>
     <artifactId>youtubedl</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
     <packaging>jar</packaging>
 
     <name>YoutubeDL wrapper</name>

--- a/src/main/java/com/sapher/youtubedl/YoutubeDL.java
+++ b/src/main/java/com/sapher/youtubedl/YoutubeDL.java
@@ -25,7 +25,7 @@ public class YoutubeDL {
     /**
      * Youtube-dl executable name
      */
-    protected static final String executableName = "youtube-dl";
+    protected static String executablePath = "youtube-dl";
 
     /**
      * Append executable name to command
@@ -33,7 +33,7 @@ public class YoutubeDL {
      * @return Command string
      */
     protected static String buildCommand(String command) {
-        return String.format("%s %s", executableName, command);
+        return String.format("%s %s", executablePath, command);
     }
 
     /**
@@ -179,5 +179,23 @@ public class YoutubeDL {
     public static List<String> getTags(String url) throws YoutubeDLException {
         VideoInfo info = getVideoInfo(url);
         return info.tags;
+    }
+
+    /**
+     * Get command executable or path to the executable
+     * @return path string
+     * @throws YoutubeDLException
+     */
+    public static String getExecutablePath(){
+        return executablePath;
+    }
+
+    /**
+     * Set path to use for the command
+     * @param path String path to the executable
+     * @throws YoutubeDLException
+     */
+    public static void setExecutablePath(String path){
+        executablePath = path;
     }
 }


### PR DESCRIPTION
Hi!

I changed a little thing in your YoutubeDL class to allow the developper to set a custom executable path for the file youtube-dl. I was working on a project with your librairie and i couldn't set the env path on my machine, either i couldn't execute the youtube-dl.exe file inside the jar. So i throught the best way to do it is to let the path "youtube-dl" as default path so if the developper want to use the env variable, there is no problem but to also let the developper set a custom path in his application.

Regards,

Le Poulet Suisse